### PR TITLE
updated me.raynes/fs to latest version 1.4.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[me.raynes/fs "1.4.0"]]
+  :dependencies [[me.raynes/fs "1.4.6"]]
   :eval-in-leiningen true
 
   :deploy-repositories [["releases" :clojars]


### PR DESCRIPTION
**Justification**
me.raynes/fs 1.4.0 contains a dependency on org.apache.commons/commons-compress 1.3.  This version of the library contains a known vulnerability.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-2098

Since the vulnerability isn't present in the generated binary the security issue is minor but it causes us some grief because it shows up on a vulnerability scan which complicates security audits.

**PR Details**
I have updated project.clj and executed the plugin for one of our projects.  Everything worked fine for me.
