### PR TITLE
fix windows parameters in preamble

### DIFF
--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -15,10 +15,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def BOOTCLASSPATH-TEMPLATE
-  ":;exec java {{{jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -Xbootclasspath/a:$0 {{{main}}} \"$@\"\n@echo off\r\njava {{{win-jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -Xbootclasspath/a:%1 {{{main}}} \"%~f0\" %*\r\ngoto :eof\r\n")
+  ":;exec java {{{jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -Xbootclasspath/a:$0 {{{main}}} \"$@\"\n@echo off\r\njava {{{win-jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -Xbootclasspath/a:\"%~f0\" {{{main}}} %*\r\ngoto :eof\r\n")
 
 (def NORMAL-TEMPLATE
-  ":;exec java {{{jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -jar $0 \"$@\"\n@echo off\r\njava {{{win-jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -jar %1 \"%~f0\" %*\r\ngoto :eof\r\n")
+  ":;exec java {{{jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -jar $0 \"$@\"\n@echo off\r\njava {{{win-jvm-opts}}} -D{{{project-name}}}.version={{{version}}} -jar \"%~f0\" %*\r\ngoto :eof\r\n")
 
 (def LEIN-JVM-OPTS ["-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-XX:-OmitStackTraceInFastThrow"])
 


### PR DESCRIPTION
* Parameters do not work correctly on windows. (`%1` used incorrectly instead of `\"%~f0\"`)
* This PR is similar to https://github.com/Raynes/lein-bin/pull/25/files



PS : do not forget to set your root password 😉 