### PR TITLE
Bumping dependency clj-zip-meta version and project version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-binplus "0.6.4"
+(defproject lein-binplus "0.6.5"
   :description "A leiningen plugin for generating standalone console
   executables for your project."
   :url "https://github.com/BrunoBonacci/lein-binplus"
@@ -11,7 +11,7 @@
 
   :dependencies [[me.raynes/fs "1.4.6"]
                  [de.ubercode.clostache/clostache "1.4.0"]
-                 [clj-zip-meta/clj-zip-meta "0.1.2" :exclusions [org.clojure/clojure]]]
+                 [clj-zip-meta/clj-zip-meta "0.1.3" :exclusions [org.clojure/clojure]]]
   :eval-in-leiningen true
 
   :deploy-repositories [["releases" :clojars]


### PR DESCRIPTION
The bump is caused by a fix (https://github.com/funcool/octet/commit/861b289a3aeb330d1f663c0475c7b0edf2d7ae67) for an issue with `funcool/octet` under clojure 1.10. This in turn caused a bump in the `clj-zip-meta` project version and now the change has percolated here in the form of a change to the dependency on `clj-zip-meta` declared in this project. 

I also took the liberty of bumping the project micro version. 