### PR TITLE
Use the fix version of dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-binplus "0.6.4"
+(defproject lein-binplus "0.6.5"
   :description "A leiningen plugin for generating standalone console
   executables for your project."
   :url "https://github.com/BrunoBonacci/lein-binplus"
@@ -11,7 +11,7 @@
 
   :dependencies [[me.raynes/fs "1.4.6"]
                  [de.ubercode.clostache/clostache "1.4.0"]
-                 [clj-zip-meta/clj-zip-meta "0.1.2"
+                 [clj-zip-meta/clj-zip-meta "0.1.3"
                   :exclusions [org.clojure/clojure]]]
 
   :eval-in-leiningen true)


### PR DESCRIPTION
- Work properly with clojure 1.10.0
- Due to bugs in funcool/octet 0.1.0
- Use clj-zip-meta 0.1.3 which have the fix to the above
- Bump version to 0.6.5