### PR TITLE
bump zip-prefixer version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,6 @@
 
   :dependencies [[me.raynes/fs "1.4.6"]
                  [de.ubercode.clostache/clostache "1.4.0"]
-                 [net.e175.klaus/zip-prefixer "0.2.0"]]
+                 [net.e175.klaus/zip-prefixer "0.3.1"]]
 
   :eval-in-leiningen true)

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -88,9 +88,9 @@
 
 
 (defn- write-preamble [^java.io.File zipfile ^String preamble]
-  (ZipPrefixer/applyPrefixesToZip
+  (ZipPrefixer/applyPrefixBytesToZip
     (.toPath zipfile)
-    (into-array [(.getBytes preamble "UTF-8")])))
+    (.getBytes preamble "UTF-8")))
 
 
 (defn- verify-zip-integrity [^java.io.File zipfile]


### PR DESCRIPTION
This bumps zip-prefixer to 0.3.1. Compared with 0.2.0, this adds a fix for a rare corner case (files that are pushed above 4 gigabyte offsets by the new preamble) and simplifies the API a little.

Not an urgent or important change but worth being added to the next release of lein-binplus, whenever that happens.
